### PR TITLE
Updated argument order for addWicket.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -87,7 +87,7 @@
             };
         });
 
-        self.addWicket = appendTo(self, self.balls, self.wickets, function (howOut, batsman, fielder) {
+        self.addWicket = appendTo(self, self.balls, self.wickets, function (batsman, howOut, fielder) {
             return {
                 'batsman': batsman || self.balls[self.balls.length - 1].batsman,
                 'howOut': howOut,

--- a/test/core.js
+++ b/test/core.js
@@ -93,7 +93,7 @@
             });
 
             it('should create a wicket', function () {
-                s.addWicket(howOut, null, fielder);
+                s.addWicket(batsman, howOut, fielder);
                 expect(s.wickets[0].batsman).to.be.equal(batsman);
                 expect(s.wickets[0].howOut).to.be.equal(howOut);
                 expect(s.wickets[0].fielder).to.be.equal(fielder);


### PR DESCRIPTION
@ryansmith94 
Great job on Scorebook! I stumbled across it a few weeks ago - its been a pleasure reading through the code. I hope you don't mind this pull request (it's my first one!).

As for the pull request: Regarding addWicket() according to the documentation the first argument should be the batsman object, the second should be the 'howOut' string, and the third, and final argument should be an optional fielder object. 

However, the batsman object and the 'howOut' string are being appended to the wicket object in the wrong order:

`book.addWicket({name: 'batsmanName'}, 'LBW') //  returns  {batsman: 'LBW', howOut: {name: 'batsmanName' }};`

I have updated the argument order, and also updated the relevant addWicket() test which now passes. Please let me know if there's anything that I can further clarify in my PR. Thanks!